### PR TITLE
Changed service root from IAT to PROD

### DIFF
--- a/client/config.php
+++ b/client/config.php
@@ -31,7 +31,7 @@ governing permissions and limitations under the License.
 	//--------------------------------------------------------------------------------------
 	// The root URL of the api calls.  Will be different between testing and production.
 	//--------------------------------------------------------------------------------------
-   	$ADP_APIROOT  = "https://iat-api.adp.com/";
+   	$ADP_APIROOT  = "https://api.adp.com/";
 
    	//--------------------------------------------------------------------------------------
    	// The location, on disk, of the certificate for the server.

--- a/test/testconfig.php
+++ b/test/testconfig.php
@@ -1,6 +1,6 @@
 <?php
 
-	$ADP_APIROOT  = "https://iat-api.adp.com/";
+	$ADP_APIROOT  = "https://api.adp.com/";
 	$ADP_CERTFILE = "../../connection/client/certs/apiclient_iat.pem";
 	$ADP_KEYFILE  = "../../connection/client/certs/apiclient_iat.key";
 	$ADP_CC_CLIENTID = "88a73992-07f2-4714-ab4b-de782acd9c4d";


### PR DESCRIPTION
Marketplace developers do not know that they do not have access to this service root. Changing this to reduce related zendesk tickets.